### PR TITLE
Fix empty state list handling

### DIFF
--- a/src/Proxy/ProxyTrait.php
+++ b/src/Proxy/ProxyTrait.php
@@ -662,6 +662,12 @@ trait ProxyTrait
      */
     private function statesIntersect(array $enabledStatesList, array $statesNames, bool $allStates): array
     {
+        if (empty($statesNames)) {
+            return [];
+        }
+
+        reset($statesNames);
+
         $inStates = [];
         $list = array_flip($enabledStatesList);
 

--- a/tests/States/Proxy/AbstractProxyTests.php
+++ b/tests/States/Proxy/AbstractProxyTests.php
@@ -483,6 +483,22 @@ abstract class AbstractProxyTests extends \PHPUnit\Framework\TestCase
         self::assertTrue($called);
     }
 
+    public function testIsInStateCallbackOnEmptyList(): void
+    {
+        $proxy = $this->buildProxy();
+
+        $called = false;
+        self::assertInstanceOf(
+            Proxy\ProxyInterface::class,
+            $proxy->isInState([], function (array $statesList) use (&$called): void {
+                $called = true;
+                self::assertSame([], $statesList);
+            })
+        );
+
+        self::assertTrue($called);
+    }
+
     /**
      * Test behavior of the proxy method inState.
      */
@@ -648,6 +664,22 @@ abstract class AbstractProxyTests extends \PHPUnit\Framework\TestCase
                 self::fail();
             }, true)
         );
+    }
+
+    public function testIsNotInStateCallbackOnEmptyList(): void
+    {
+        $proxy = $this->buildProxy();
+
+        $called = false;
+        self::assertInstanceOf(
+            Proxy\ProxyInterface::class,
+            $proxy->isNotInState([], function (array $statesList) use (&$called): void {
+                $called = true;
+                self::assertSame([], $statesList);
+            })
+        );
+
+        self::assertTrue($called);
     }
 
     /**


### PR DESCRIPTION
## Summary
- prevent TypeError when checking states with an empty list
- test `isInState()` with an empty list
- test `isNotInState()` with an empty list

## Testing
- `vendor/bin/phpunit -c phpunit.xml`
- `vendor/bin/phpstan analyse src infrastructures --level max`

------
https://chatgpt.com/codex/tasks/task_e_684829dc1d38832d97706d3b7cd12883