### PR TITLE
Refactor functional tests to use exception expectations

### DIFF
--- a/tests/States/Functional/ArticleTest.php
+++ b/tests/States/Functional/ArticleTest.php
@@ -32,6 +32,7 @@ use Teknoo\Tests\Support\Article\Article\Extended;
 use Teknoo\Tests\Support\Article\Article\Promoted;
 use Teknoo\Tests\Support\Article\Article\Published;
 use Teknoo\Tests\Support\Article\Article\StateDefault;
+use Teknoo\States\Proxy\Exception\MethodNotImplemented;
 
 /**
  * Class ArticleTest
@@ -76,68 +77,28 @@ class ArticleTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('title 2', $article->getTitle());
 
         //Method not available, because state Draft is not enabled
-        $fail = false;
-        try {
-            $article->setTitle('Hello world');
-        } catch (\Exception) {
-            $fail = true;
-        }
-
-        if (!$fail) {
-            self::fail('Error, the lib must throw an exception because the method is not available in enabled states');
-        }
+        $this->expectException(MethodNotImplemented::class);
+        $article->setTitle('Hello world');
 
         //Method not available, because state Draft is not enabled
-        $fail = false;
-        try {
-            $article->setBody('Lorem [b]Ipsum[/b]');
-        } catch (\Exception) {
-            $fail = true;
-        }
-
-        if (!$fail) {
-            self::fail('Error, the lib must throw an exception because the method is not available in enabled states');
-        }
+        $this->expectException(MethodNotImplemented::class);
+        $article->setBody('Lorem [b]Ipsum[/b]');
 
         self::assertEquals('title 2', $article->getTitle());
 
         //Method not available, because state Draft is not enabled
-        $fail = false;
-        try {
-            $article->getBodySource();
-        } catch (\Exception) {
-            $fail = true;
-        }
-
-        if (!$fail) {
-            self::fail('Error, the lib must throw an exception because the method is not available in enabled states');
-        }
+        $this->expectException(MethodNotImplemented::class);
+        $article->getBodySource();
 
         //Method not available, because state Draft is not enabled
-        $fail = false;
-        try {
-            $article->publishing();
-        } catch (\Exception) {
-            $fail = true;
-        }
-
-        if (!$fail) {
-            self::fail('Error, the lib must throw an exception because the method is not available in enabled states');
-        }
+        $this->expectException(MethodNotImplemented::class);
+        $article->publishing();
 
         self::assertEquals('title 2', $article->getTitle());
         self::assertEquals('body 2', $article->getFormattedBody());
 
-        $fail = false;
-        try {
-            $article->getDate();
-        } catch (\Exception) {
-            $fail = true;
-        }
-
-        if (!$fail) {
-            self::fail('Error, the lib must throw an exception because the method is not available in enabled states');
-        }
+        $this->expectException(MethodNotImplemented::class);
+        $article->getDate();
     }
 
     public function testStatesFullQualifiedClassName(): void

--- a/tests/States/Functional/MultipleTest.php
+++ b/tests/States/Functional/MultipleTest.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
 
 namespace Teknoo\Tests\States\Functional;
 
+use Teknoo\States\Proxy\Exception\MethodNotImplemented;
 use Teknoo\Tests\Support\Multiple\User\User;
 
 /**
@@ -52,16 +53,8 @@ class MultipleTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('admin', $administrator->getName());
 
         //Method not available, because state Moderator is not enabled
-        $fail = false;
-        try {
-            $simpleUser->isModerator();
-        } catch (\Exception) {
-            $fail = true;
-        }
-
-        if (!$fail) {
-            self::fail('Error, the lib must throw an exception because the method is not available in enabled states');
-        }
+        $this->expectException(MethodNotImplemented::class);
+        $simpleUser->isModerator();
 
         self::assertTrue($moderator->isModerator());
         self::assertTrue($administrator->isModerator());


### PR DESCRIPTION
## Summary
- streamline Functional Article and Multiple tests
- check for `MethodNotImplemented` exceptions using PHPUnit expectations

## Testing
- `vendor/bin/phpunit tests/States/Functional/ArticleTest.php tests/States/Functional/MultipleTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68482b4898e4832d81e3a750649ad806